### PR TITLE
refactor: migrate sign package to use standard lib and code betterments

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Check out code
       uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -43,9 +43,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
-      - name: Install libsodium
-        run: sudo apt install libsodium-dev
 
       - name: Run Unit tests
         run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/pokt-foundation/pocket-go
 go 1.18
 
 require (
-	github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb
 	github.com/gojektech/heimdall v5.0.2+incompatible
 	github.com/jarcoal/httpmock v1.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb h1:ilqSFSbR1fq6x88heeHrvAqlg+ES+tZk2ZcaCmiH1gI=
-github.com/GoKillers/libsodium-go v0.0.0-20171022220152-dd733721c3cb/go.mod h1:72TQeEkiDH9QMXZa5nJJvZre0UjqqO67X2QEIoOwCRU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gojektech/heimdall v5.0.2+incompatible h1:mfGLnHNTKN7b1OMTO4ZvL3oT2P13kqTTV7owK7BZDck=

--- a/pkg/provider/rpc_responses.go
+++ b/pkg/provider/rpc_responses.go
@@ -63,7 +63,7 @@ type GetAppResponse struct {
 	Status        int       `json:"status"`
 	Chains        []string  `json:"chains"`
 	Tokens        string    `json:"tokens"`
-	MaxRelays     *int      `json:"max_relays"`
+	MaxRelays     int       `json:"max_relays"`
 	UnstakingTime time.Time `json:"unstaking_time"`
 }
 
@@ -80,7 +80,7 @@ type GetNodeResponse struct {
 	Chains        []string  `json:"chains"`
 	Jailed        bool      `json:"jailed"`
 	PublicKey     string    `json:"public_key"`
-	ServiceURL    *string   `json:"service_url"`
+	ServiceURL    string    `json:"service_url"`
 	Status        int       `json:"status"`
 	Tokens        string    `json:"tokens"`
 	UnstakingTime time.Time `json:"unstaking_time"`

--- a/pkg/relayer/pocket_relayer.go
+++ b/pkg/relayer/pocket_relayer.go
@@ -82,16 +82,15 @@ func (r *PocketRelayer) validateRelayRequest(input *RelayInput) error {
 }
 
 func getNode(input *RelayInput) (*provider.Node, error) {
-	node := input.Node
-	if node == nil {
-		node = GetRandomSessionNode(input.Session)
-	} else {
-		if !IsNodeInSession(input.Session, node) {
-			return nil, ErrNodeNotInSession
-		}
+	if input.Node == nil {
+		return GetRandomSessionNode(input.Session), nil
 	}
 
-	return node, nil
+	if !IsNodeInSession(input.Session, input.Node) {
+		return nil, ErrNodeNotInSession
+	}
+
+	return input.Node, nil
 }
 
 func (r *PocketRelayer) getSignedProofBytes(proof *provider.RelayProof) (string, error) {

--- a/pkg/signer/key_manager.go
+++ b/pkg/signer/key_manager.go
@@ -1,11 +1,10 @@
 package signer
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
-	"fmt"
 
-	"github.com/GoKillers/libsodium-go/cryptosign"
 	"github.com/pokt-foundation/pocket-go/pkg/utils"
 )
 
@@ -25,9 +24,9 @@ type KeyManager struct {
 
 // NewRandomKeyManager returns a KeyManager with random keys
 func NewRandomKeyManager() (*KeyManager, error) {
-	privateKey, publicKey, exit := cryptosign.CryptoSignKeyPair()
-	if exit != 0 {
-		return nil, fmt.Errorf(fmt.Sprintf("Exit code: %v", exit), ErrCryptoSignKeyPair)
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, err
 	}
 
 	address, err := utils.GetAddressFromDecodedPublickey(publicKey)
@@ -66,12 +65,7 @@ func (km *KeyManager) Sign(payload []byte) (string, error) {
 		return "", err
 	}
 
-	signature, exit := cryptosign.CryptoSignDetached(payload, decodedKey)
-	if exit != 0 {
-		return "", fmt.Errorf(fmt.Sprintf("Exit code: %v", exit), ErrCryptoSignDetached)
-	}
-
-	return hex.EncodeToString(signature), nil
+	return hex.EncodeToString(ed25519.Sign(decodedKey, payload)), nil
 }
 
 // GetAddress returns address value

--- a/pkg/signer/key_manager.go
+++ b/pkg/signer/key_manager.go
@@ -3,16 +3,8 @@ package signer
 import (
 	"crypto/ed25519"
 	"encoding/hex"
-	"errors"
 
 	"github.com/pokt-foundation/pocket-go/pkg/utils"
-)
-
-var (
-	// ErrCryptoSignDetached is error when ErrCryptoSignDetached function exits value other than 0
-	ErrCryptoSignDetached = errors.New("error in CryptoSignDetached")
-	// ErrCryptoSignKeyPair is error when ErrCryptoSignKeyPair function exits value other than 0
-	ErrCryptoSignKeyPair = errors.New("error in CryptoSignKeyPair")
 )
 
 // KeyManager struct handler


### PR DESCRIPTION
- Migrate sign package to use `ed25519` library from the standard library.

- Do some code betterments (take out pointers where they shouldn't be and some nested ifs).

Closes #20 