### PR TITLE
fix: change max relays field to be string

### DIFF
--- a/pkg/provider/rpc_responses.go
+++ b/pkg/provider/rpc_responses.go
@@ -63,7 +63,7 @@ type GetAppResponse struct {
 	Status        int       `json:"status"`
 	Chains        []string  `json:"chains"`
 	Tokens        string    `json:"tokens"`
-	MaxRelays     int       `json:"max_relays"`
+	MaxRelays     string    `json:"max_relays"`
 	UnstakingTime time.Time `json:"unstaking_time"`
 }
 

--- a/pkg/provider/samples/query_app.json
+++ b/pkg/provider/samples/query_app.json
@@ -7,6 +7,6 @@
       "string"
     ],
     "tokens": "string",
-    "max_relays": 0,
+    "max_relays": "0",
     "unstaking_time": "0001-01-01T00:00:00Z"
 }

--- a/pkg/provider/samples/query_apps.json
+++ b/pkg/provider/samples/query_apps.json
@@ -9,7 +9,7 @@
 		  "string"
 		],
 		"tokens": "string",
-		"max_relays": 0,
+		"max_relays": "0",
 		"unstaking_time": "0001-01-01T00:00:00Z"
 	  }
 	],


### PR DESCRIPTION
Change `MaxRelays` field in `GetAppResponse` struct to be string because that is the actual response from the rpc request.