### PR TITLE
feat: add relay error codes to provider package

### DIFF
--- a/pkg/provider/json_rpc_provider.go
+++ b/pkg/provider/json_rpc_provider.go
@@ -552,7 +552,7 @@ func parseRelayErrorResponse(bodyBytes []byte, servicerPubKey string) error {
 	}
 
 	return &RelayError{
-		Code:           response.Error.Code,
+		Code:           RelayErrorCode(response.Error.Code),
 		Codespace:      response.Error.Message,
 		Message:        response.Error.Message,
 		ServicerPubKey: servicerPubKey,

--- a/pkg/provider/json_rpc_provider.go
+++ b/pkg/provider/json_rpc_provider.go
@@ -552,7 +552,7 @@ func parseRelayErrorResponse(bodyBytes []byte, servicerPubKey string) error {
 	}
 
 	return &RelayError{
-		Code:           RelayErrorCode(response.Error.Code),
+		Code:           response.Error.Code,
 		Codespace:      response.Error.Message,
 		Message:        response.Error.Message,
 		ServicerPubKey: servicerPubKey,

--- a/pkg/provider/json_rpc_provider_test.go
+++ b/pkg/provider/json_rpc_provider_test.go
@@ -377,12 +377,14 @@ func TestJSONRPCProvider_Relay(t *testing.T) {
 
 	relay, err = provider.Relay("https://dummy.com", &Relay{}, nil)
 	c.Equal(Err5xxOnConnection, err)
+	c.False(IsErrorCode(EmptyPayloadDataError, err))
 	c.Empty(relay)
 
 	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", ClientRelayRoute), http.StatusBadRequest, "samples/client_relay_error.json")
 
 	relay, err = provider.Relay("https://dummy.com", &Relay{Proof: &RelayProof{ServicerPubKey: "PJOG"}}, nil)
 	c.Equal("Request failed with code: 25, codespace: the payload data of the relay request is empty and message: the payload data of the relay request is empty\nWith ServicerPubKey: PJOG", err.Error())
+	c.True(IsErrorCode(EmptyPayloadDataError, err))
 	c.Empty(relay)
 
 	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", ClientRelayRoute), http.StatusOK, "samples/no_json.txt")

--- a/pkg/provider/relay.go
+++ b/pkg/provider/relay.go
@@ -96,3 +96,13 @@ const (
 	// UnsupportedBlockchainError error when sent blockchain is not supported yet
 	UnsupportedBlockchainError RelayErrorCode = 76
 )
+
+// IsErrorCode returns if error has the same relay error code as input
+func IsErrorCode(code RelayErrorCode, err error) bool {
+	castedErr, ok := err.(*RelayError)
+	if !ok {
+		return false
+	}
+
+	return castedErr.Code == code
+}

--- a/pkg/provider/relay.go
+++ b/pkg/provider/relay.go
@@ -48,9 +48,9 @@ type PocketAAT struct {
 // RelayErrorResponse represents error response of relay request
 type RelayErrorResponse struct {
 	Error struct {
-		Code      int    `json:"code"`
-		Codespace string `json:"codespace"`
-		Message   string `json:"message"`
+		Code      RelayErrorCode `json:"code"`
+		Codespace string         `json:"codespace"`
+		Message   string         `json:"message"`
 	} `json:"error"`
 }
 

--- a/pkg/provider/relay.go
+++ b/pkg/provider/relay.go
@@ -56,7 +56,7 @@ type RelayErrorResponse struct {
 
 // RelayError represents the thrown error of a relay request
 type RelayError struct {
-	Code           int
+	Code           RelayErrorCode
 	Codespace      string
 	Message        string
 	ServicerPubKey string
@@ -68,3 +68,31 @@ func (e *RelayError) Error() string {
 	return fmt.Sprintf("Request failed with code: %v, codespace: %s and message: %s\nWith ServicerPubKey: %s",
 		e.Code, e.Codespace, e.Message, e.ServicerPubKey)
 }
+
+// RelayErrorCode is enum of possible relay error codes
+type RelayErrorCode int
+
+const (
+	// AppNotFoundError error when app is not found
+	AppNotFoundError RelayErrorCode = 45
+	// DuplicateProofError error when proof is used multiple times
+	DuplicateProofError RelayErrorCode = 37
+	// EmptyPayloadDataError error when sent payload is empty
+	EmptyPayloadDataError RelayErrorCode = 25
+	// EvidencedSealedError error when evidence is sealed, either max relays reached or claim already submitted
+	EvidencedSealedError RelayErrorCode = 90
+	// HTTPExecutionError error when http request failed
+	HTTPExecutionError RelayErrorCode = 28
+	// InvalidBlockHeightError error when sent block height is invalid
+	InvalidBlockHeightError RelayErrorCode = 60
+	// InvalidSessionError error when session is invalid
+	InvalidSessionError RelayErrorCode = 14
+	// OutOfSyncRequestError error when request is not on sync
+	OutOfSyncRequestError RelayErrorCode = 75
+	// OverServiceError error when request exceeds service capacity
+	OverServiceError RelayErrorCode = 71
+	// RequestHashError error when hash is not correct
+	RequestHashError RelayErrorCode = 74
+	// UnsupportedBlockchainError error when sent blockchain is not supported yet
+	UnsupportedBlockchainError RelayErrorCode = 76
+)


### PR DESCRIPTION
Add relay error codes enum to provider package so SDK clients can know easier what error happened on the RPC request

Example of usage:

```
	relay, err := pocketRelayer.Relay(&RelayInput{
		Blockchain: "0021",
		Data:       `{"id":3905054414,"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}`,
		Method:     http.MethodPost,
		PocketAAT: &provider.PocketAAT{
			Version:      "0.0.1",
			AppPubKey:    "ec1",
			ClientPubKey: "e7e",
			Signature:    "a265adf",
		},
		Session: session,
	}, nil)
	if err != nil {
		if provider.IsErrorCode(provider.EvidencedSealedError, err) {
			// do stuff
		}
	}
```