### PR TITLE
Change session struct to have header as a different struct

### DIFF
--- a/pkg/provider/json_rpc_provider.go
+++ b/pkg/provider/json_rpc_provider.go
@@ -552,7 +552,7 @@ func parseRelayErrorResponse(bodyBytes []byte, servicerPubKey string) error {
 	}
 
 	return &RelayError{
-		Code:           response.Error.Code,
+		Code:           RelayErrorCode(response.Error.Code),
 		Codespace:      response.Error.Message,
 		Message:        response.Error.Message,
 		ServicerPubKey: servicerPubKey,

--- a/pkg/provider/json_rpc_provider.go
+++ b/pkg/provider/json_rpc_provider.go
@@ -552,7 +552,7 @@ func parseRelayErrorResponse(bodyBytes []byte, servicerPubKey string) error {
 	}
 
 	return &RelayError{
-		Code:           RelayErrorCode(response.Error.Code),
+		Code:           response.Error.Code,
 		Codespace:      response.Error.Message,
 		Message:        response.Error.Message,
 		ServicerPubKey: servicerPubKey,

--- a/pkg/provider/rpc_responses.go
+++ b/pkg/provider/rpc_responses.go
@@ -270,14 +270,17 @@ type DispatchResponse struct {
 
 // Session represents session response from RPC request
 type Session struct {
-	BlockHeight int `json:"block_height"`
-	Header      struct {
-		AppPublicKey  string `json:"app_public_key"`
-		Chain         string `json:"chain"`
-		SessionHeight int    `json:"session_height"`
-	} `json:"header"`
-	Key   string  `json:"key"`
-	Nodes []*Node `json:"nodes"`
+	BlockHeight int            `json:"block_height"`
+	Header      *SessionHeader `json:"header"`
+	Key         string         `json:"key"`
+	Nodes       []*Node        `json:"nodes"`
+}
+
+// SessionHeader represents the headers of a session response
+type SessionHeader struct {
+	AppPublicKey  string `json:"app_public_key"`
+	Chain         string `json:"chain"`
+	SessionHeight int    `json:"session_height"`
 }
 
 // Node represents node response from RPC request

--- a/pkg/relayer/pocket_relayer.go
+++ b/pkg/relayer/pocket_relayer.go
@@ -17,6 +17,8 @@ var (
 	ErrNoSigner = errors.New("no signer provided")
 	// ErrNoSession error when no session is provided
 	ErrNoSession = errors.New("no session provided")
+	// ErrNoSessionHeader error when no session header is provided
+	ErrNoSessionHeader = errors.New("no session header provided")
 	// ErrNoProvider error when no provider is provided
 	ErrNoProvider = errors.New("no provider provided")
 	// ErrNoPocketAAT error when no Pocket AAT is provided
@@ -76,6 +78,10 @@ func (r *PocketRelayer) validateRelayRequest(input *RelayInput) error {
 
 	if len(input.Session.Nodes) == 0 {
 		return ErrSessionHasNoNodes
+	}
+
+	if input.Session.Header == nil {
+		return ErrNoSessionHeader
 	}
 
 	return nil

--- a/pkg/relayer/pocket_relayer_test.go
+++ b/pkg/relayer/pocket_relayer_test.go
@@ -96,8 +96,14 @@ func TestPocketRelayer_Relay(t *testing.T) {
 	c.Equal(ErrSessionHasNoNodes, err)
 	c.Empty(relay)
 
-	relayInput.Node = &provider.Node{PublicKey: "PJOG"}
 	relayInput.Session.Nodes = []*provider.Node{{PublicKey: "AOG"}}
+
+	relay, err = relayer.Relay(relayInput, nil)
+	c.Equal(ErrNoSessionHeader, err)
+	c.Empty(relay)
+
+	relayInput.Session.Header = &provider.SessionHeader{}
+	relayInput.Node = &provider.Node{PublicKey: "PJOG"}
 
 	relay, err = relayer.Relay(relayInput, nil)
 	c.Equal(ErrNodeNotInSession, err)


### PR DESCRIPTION
Change session struct to have header fields as a different structure to ease conversion for clients.