### PR TITLE
refactor: change random package and fix panic

### DIFF
--- a/pkg/provider/interfaces.go
+++ b/pkg/provider/interfaces.go
@@ -22,7 +22,7 @@ type Provider interface {
 	GetApp(address string, options *GetAppOptions) (*GetAppResponse, error)
 	GetAccount(address string, options *GetAccountOptions) (*GetAccountResponse, error)
 	GetAccountWithTransactions(address string) (*GetAccountWithTransactionsResponse, error)
-	Dispatch(appPublicKey, chain string, sessionHeight int, options *DispatchRequestOptions) (*DispatchResponse, error)
+	Dispatch(appPublicKey, chain string, options *DispatchRequestOptions) (*DispatchResponse, error)
 	Relay(rpcURL string, input *Relay, options *RelayRequestOptions) (*RelayResponse, error)
 	// TODO: Add methods for params/requestChallenge
 }

--- a/pkg/provider/json_rpc_provider_test.go
+++ b/pkg/provider/json_rpc_provider_test.go
@@ -346,7 +346,7 @@ func TestJSONRPCProvider_Dispatch(t *testing.T) {
 		client: providerClient,
 	}
 
-	dispatch, err := provider.Dispatch("pjog", "abcd", 21, nil)
+	dispatch, err := provider.Dispatch("pjog", "abcd", &DispatchRequestOptions{Height: 21})
 	c.Equal(ErrNoDispatchers, err)
 	c.Empty(dispatch)
 
@@ -354,13 +354,13 @@ func TestJSONRPCProvider_Dispatch(t *testing.T) {
 
 	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", ClientDispatchRoute), http.StatusOK, "samples/client_dispatch.json")
 
-	dispatch, err = provider.Dispatch("pjog", "abcd", 21, nil)
+	dispatch, err = provider.Dispatch("pjog", "abcd", &DispatchRequestOptions{Height: 21})
 	c.NoError(err)
 	c.NotEmpty(dispatch)
 
 	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", ClientDispatchRoute), http.StatusInternalServerError, "samples/client_dispatch.json")
 
-	dispatch, err = provider.Dispatch("pjog", "abcd", 21, nil)
+	dispatch, err = provider.Dispatch("pjog", "abcd", &DispatchRequestOptions{Height: 21})
 	c.Equal(Err5xxOnConnection, err)
 	c.Empty(dispatch)
 }

--- a/pkg/provider/options.go
+++ b/pkg/provider/options.go
@@ -48,6 +48,7 @@ type GetAppsOptions struct {
 
 // DispatchRequestOptions represents optional arguments for Dispatch request
 type DispatchRequestOptions struct {
+	Height                       int
 	RejectSelfSignedCertificates bool
 }
 

--- a/pkg/provider/relay.go
+++ b/pkg/provider/relay.go
@@ -35,7 +35,7 @@ type RelayPayload struct {
 // RelayProof represents proof of a relay
 type RelayProof struct {
 	RequestHash        string     `json:"request_hash"`
-	Entropy            int        `json:"entropy"`
+	Entropy            int64      `json:"entropy"`
 	SessionBlockHeight int        `json:"session_block_height"`
 	ServicerPubKey     string     `json:"servicer_pub_key"`
 	Blockchain         string     `json:"blockchain"`

--- a/pkg/relayer/models.go
+++ b/pkg/relayer/models.go
@@ -32,7 +32,7 @@ type Response struct {
 
 // Order of fields matters for signature
 type relayProofForSignature struct {
-	Entropy            int    `json:"entropy"`
+	Entropy            int64  `json:"entropy"`
 	SessionBlockHeight int    `json:"session_block_height"`
 	ServicerPubKey     string `json:"servicer_pub_key"`
 	Blockchain         string `json:"blockchain"`


### PR DESCRIPTION
- Change random package to be the `crypto` one for more accurate randomness.
- Fix panic on relay request when there was an error.
- Change `Dispatch` function to send Heigh as an optional parameter.