### PR TITLE
fix: fix typo causing double messages on errors

### DIFF
--- a/pkg/provider/json_rpc_provider.go
+++ b/pkg/provider/json_rpc_provider.go
@@ -612,7 +612,7 @@ func parseRelayErrorOutput(bodyBytes []byte, servicerPubKey string) error {
 
 	return &RelayError{
 		Code:           output.Error.Code,
-		Codespace:      output.Error.Message,
+		Codespace:      output.Error.Codespace,
 		Message:        output.Error.Message,
 		ServicerPubKey: servicerPubKey,
 	}

--- a/pkg/provider/json_rpc_provider_test.go
+++ b/pkg/provider/json_rpc_provider_test.go
@@ -385,7 +385,7 @@ func TestJSONRPCProvider_Relay(t *testing.T) {
 	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", ClientRelayRoute), http.StatusBadRequest, "samples/client_relay_error.json")
 
 	relay, err = provider.Relay("https://dummy.com", &Relay{Proof: &RelayProof{ServicerPubKey: "PJOG"}}, nil)
-	c.Equal("Request failed with code: 25, codespace: the payload data of the relay request is empty and message: the payload data of the relay request is empty\nWith ServicerPubKey: PJOG", err.Error())
+	c.Equal("Request failed with code: 25, codespace: pocketcore and message: the payload data of the relay request is empty\nWith ServicerPubKey: PJOG", err.Error())
 	c.True(IsErrorCode(EmptyPayloadDataError, err))
 	c.Empty(relay)
 


### PR DESCRIPTION
Send `CodeSpace` correctly in error constructor.