### PR TITLE
feat: add timeout and retries as options to reqs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -44,6 +44,14 @@ func NewDefaultClient() *Client {
 
 // NewCustomClient returns httpclient instance with given custom config
 func NewCustomClient(retries int, timeout time.Duration) *Client {
+	if retries == 0 {
+		retries = defaultHTTPClientRetries
+	}
+
+	if timeout == 0*time.Second {
+		timeout = defaultHTTPClientTimeout
+	}
+
 	return &Client{
 		Client: httpclient.NewClient(
 			httpclient.WithHTTPTimeout(timeout),

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -18,6 +18,9 @@ func TestNewDefaultClient(t *testing.T) {
 
 	client = NewCustomClient(5, 3*time.Second)
 	c.NotEmpty(client)
+
+	client = NewCustomClient(0, 0*time.Second)
+	c.NotEmpty(client)
 }
 
 func TestClient_PostWithURLJSONParams(t *testing.T) {
@@ -29,7 +32,7 @@ func TestClient_PostWithURLJSONParams(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	mock.AddMockedResponseFromFile(http.MethodPost, "https://dummy.com", http.StatusCreated, "../mock-client/samples/dummy.json")
+	mock.AddMockedResponseFromFile(http.MethodPost, "https://dummy.com", http.StatusCreated, "../../pkg/mock-client/samples/dummy.json")
 
 	response, err := client.PostWithURLJSONParams("https://dummy.com", map[string]interface{}{
 		"ohana": "family",

--- a/pkg/mock-client/mock_test.go
+++ b/pkg/mock-client/mock_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/pokt-foundation/pocket-go/pkg/client"
+	"github.com/pokt-foundation/pocket-go/internal/client"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/provider/interfaces.go
+++ b/pkg/provider/interfaces.go
@@ -11,11 +11,11 @@ type Provider interface {
 	GetTransactionCount(address string, options *GetTransactionCountOptions) (int, error)
 	GetType(address string, options *GetTypeOptions) (AddressType, error)
 	// TXs
-	SendTransaction(signerAddress string, signedTransaction string) (*SendTransactionOutput, error)
+	SendTransaction(signerAddress string, signedTransaction string, options *SendTransactionOptions) (*SendTransactionOutput, error)
 	// Network
-	GetBlock(blockNumber int) (*GetBlockOutput, error)
+	GetBlock(blockNumber int, options *GetBlockOptions) (*GetBlockOutput, error)
 	GetTransaction(transactionHash string, options *GetTransactionOptions) (*GetTransactionOutput, error)
-	GetBlockHeight() (int, error)
+	GetBlockHeight(options *GetBlockHeightOptions) (int, error)
 	GetNodes(height int, options *GetNodesOptions) (*GetNodesOutput, error)
 	GetNode(address string, options *GetNodeOptions) (*GetNodeOutput, error)
 	GetApps(height int, options *GetAppsOptions) (*GetAppsOutput, error)

--- a/pkg/provider/options.go
+++ b/pkg/provider/options.go
@@ -1,75 +1,218 @@
 package provider
 
+import "time"
+
 // GetBalanceOptions represents optional arguments for GetBalance request
 type GetBalanceOptions struct {
-	Height int
+	Height         int
+	RequestOptions *RequestOptions
+}
+
+func (o *GetBalanceOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // GetNodeOptions represents optional arguments for GetNode request
 type GetNodeOptions struct {
-	Height int
+	Height         int
+	RequestOptions *RequestOptions
+}
+
+func (o *GetNodeOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // GetNodesOptions represents optional arguments for GetNodes request
 type GetNodesOptions struct {
-	StakingStatus StakingStatus
-	Page          int
-	PerPage       int
-	BlockChain    string
-	JailedStatus  JailedStatus
+	StakingStatus  StakingStatus
+	Page           int
+	PerPage        int
+	BlockChain     string
+	JailedStatus   JailedStatus
+	RequestOptions *RequestOptions
+}
+
+func (o *GetNodesOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // GetAccountTransactionsOptions represents optional arguments for GetAccountTransactions request
 type GetAccountTransactionsOptions struct {
-	Height   int
-	Page     int
-	PerPage  int
-	Prove    bool
-	Received bool
-	Order    Order
+	Height         int
+	Page           int
+	PerPage        int
+	Prove          bool
+	Received       bool
+	Order          Order
+	RequestOptions *RequestOptions
+}
+
+func (o *GetAccountTransactionsOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // GetTransactionCountOptions represents optional arguments for GetTransactionCount request
 type GetTransactionCountOptions struct {
-	Height   int
-	Received bool
+	Height         int
+	Received       bool
+	RequestOptions *RequestOptions
 }
 
 // GetAppOptions represents optional arguments for GetApp request
 type GetAppOptions struct {
-	Height int
+	Height         int
+	RequestOptions *RequestOptions
+}
+
+func (o *GetAppOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // GetAccountOptions represents optional arguments for GetAccount request
 type GetAccountOptions struct {
-	Height int
+	Height         int
+	RequestOptions *RequestOptions
+}
+
+func (o *GetAccountOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // GetTypeOptions represents optional arguments for GetType request
 type GetTypeOptions struct {
-	Height int
+	Height         int
+	RequestOptions *RequestOptions
 }
 
 // GetAppsOptions represents optional arguments for GetApps request
 type GetAppsOptions struct {
-	StakingStatus StakingStatus
-	Page          int
-	PerPage       int
-	BlockChain    string
+	StakingStatus  StakingStatus
+	Page           int
+	PerPage        int
+	BlockChain     string
+	RequestOptions *RequestOptions
+}
+
+func (o *GetAppsOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // DispatchRequestOptions represents optional arguments for Dispatch request
 type DispatchRequestOptions struct {
 	Height                       int
 	RejectSelfSignedCertificates bool
+	RequestOptions               *RequestOptions
+}
+
+func (o *DispatchRequestOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // RelayRequestOptions represents optional arguments for Relay request
 type RelayRequestOptions struct {
 	RejectSelfSignedCertificates bool
+	RequestOptions               *RequestOptions
+}
+
+func (o *RelayRequestOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
 }
 
 // GetTransactionOptions represents the optional arguments for a GetTransaction request
 type GetTransactionOptions struct {
-	Prove bool
+	Prove          bool
+	RequestOptions *RequestOptions
+}
+
+func (o *GetTransactionOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
+}
+
+// SendTransactionOptions represents optional arguments for a SendTransaction request
+type SendTransactionOptions struct {
+	RequestOptions *RequestOptions
+}
+
+func (o *SendTransactionOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
+}
+
+// GetBlockOptions represents optional arguments for a GetBlock request
+type GetBlockOptions struct {
+	RequestOptions *RequestOptions
+}
+
+func (o *GetBlockOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
+}
+
+// GetBlockHeightOptions represents optional arguments for a GetBlockHeight request
+type GetBlockHeightOptions struct {
+	RequestOptions *RequestOptions
+}
+
+func (o *GetBlockHeightOptions) getRequestOptions() *RequestOptions {
+	if o == nil {
+		return nil
+	}
+
+	return o.RequestOptions
+}
+
+// RequestOptions represents optional arguments related to the HTTP request itself
+type RequestOptions struct {
+	HTTPTimeout time.Duration
+	HTTPRetries int
+}
+
+type requester interface {
+	getRequestOptions() *RequestOptions
 }

--- a/pkg/relayer/pocket_relayer_test.go
+++ b/pkg/relayer/pocket_relayer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/pokt-foundation/pocket-go/pkg/client"
 	"github.com/pokt-foundation/pocket-go/pkg/mock-client"
 	"github.com/pokt-foundation/pocket-go/pkg/provider"
 	"github.com/pokt-foundation/pocket-go/pkg/signer"
@@ -46,7 +45,7 @@ func TestPocketRelayer_Relay(t *testing.T) {
 	c.Equal(ErrNoProvider, err)
 	c.Empty(relay)
 
-	relayer.provider = provider.NewJSONRPCProvider("https://dummy.com", []string{"https://dummy.com"}, client.NewDefaultClient())
+	relayer.provider = provider.NewJSONRPCProvider("https://dummy.com", []string{"https://dummy.com"})
 
 	relay, err = relayer.Relay(relayInput, nil)
 	c.Equal(ErrNoSession, err)

--- a/pkg/signer/wallet_test.go
+++ b/pkg/signer/wallet_test.go
@@ -3,7 +3,6 @@ package signer
 import (
 	"testing"
 
-	"github.com/pokt-foundation/pocket-go/pkg/client"
 	"github.com/pokt-foundation/pocket-go/pkg/provider"
 	"github.com/pokt-foundation/pocket-go/pkg/utils"
 	"github.com/stretchr/testify/require"
@@ -56,7 +55,7 @@ func TestWallet_Connect(t *testing.T) {
 	wallet, err := NewRandomWallet()
 	c.NoError(err)
 
-	wallet.Connect(provider.NewJSONRPCProvider("https://dummy.com", []string{"https://dummy.com"}, client.NewDefaultClient()))
+	wallet.Connect(provider.NewJSONRPCProvider("https://dummy.com", []string{"https://dummy.com"}))
 
 	c.True(wallet.IsSigner())
 	c.NotEmpty(wallet.GetProvider())


### PR DESCRIPTION
- Add timeout and retries as optional params to all provider functions for HTTP requests.
- Change usage of `Client` struct so it is not sent explicitly in the `Provider` constructor.
- Move client package to internal since it is not used explicitly anymore.

Example of usage:

```
dummy, err := provider.GetDummy(&GetDummyOptionsOptions{RequestOptions: &RequestOptions{
        HTTPRetries: 3, 
        HTTPTimeout: 4 * time.Second}})
if err != nil {
	return err
}
```

Closes #31 
Close T-2780