### PR TITLE
refactor: change message value to be map

### DIFF
--- a/provider/transaction.go
+++ b/provider/transaction.go
@@ -62,8 +62,8 @@ type Transaction struct {
 		} `json:"fee"`
 		Memo string `json:"memo"`
 		Msg  struct {
-			Type  string      `json:"type"`
-			Value interface{} `json:"value"`
+			Type  string                 `json:"type"`
+			Value map[string]interface{} `json:"value"`
 		} `json:"msg"`
 		Signature struct {
 			PubKey    string `json:"pub_key"`


### PR DESCRIPTION
Change `Value` in `Msg` to be a map to it is easier to get the values, example of usage:

`transactions, _ := provider.GetBlockTransactions(3730, nil)
rawVal := transactions.Txs[0].StdTx.Msg.Value["amount"]
if rawVal != nil {
	val, ok := rawVal.(string)
	if !ok {
		doStuff("")
	}
	doStuff(val)
}`