### PR TITLE
feat: parse stdtx msg

### DIFF
--- a/transaction-builder/parse_stdtx_msg.go
+++ b/transaction-builder/parse_stdtx_msg.go
@@ -1,7 +1,6 @@
-package utils
+package transactionbuilder
 
 import (
-	transactionbuilder "github.com/pokt-foundation/pocket-go/transaction-builder"
 	nodesTypes "github.com/pokt-network/pocket-core/x/nodes/types"
 )
 
@@ -12,11 +11,11 @@ type StdTxMsg struct {
 }
 
 // ParseStdTxMsg parses any StdTx.Msg.Value and returns a typed struct
-func ParseStdTxMsg(msg StdTxMsg) (transactionbuilder.TransactionMessage, error) {
+func ParseStdTxMsg(msg StdTxMsg) (TransactionMessage, error) {
 	switch msg.Type {
 	case "pos/Send":
 		parsedValue := msg.Value.(*nodesTypes.MsgSend)
-		return transactionbuilder.NewSend(parsedValue.FromAddress.String(), parsedValue.ToAddress.String(), parsedValue.Amount.Int64())
+		return NewSend(parsedValue.FromAddress.String(), parsedValue.ToAddress.String(), parsedValue.Amount.Int64())
 	default:
 		return nil, nil
 	}

--- a/utils/parse_stdtx_msg.go
+++ b/utils/parse_stdtx_msg.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	transactionbuilder "github.com/pokt-foundation/pocket-go/transaction-builder"
+	nodesTypes "github.com/pokt-network/pocket-core/x/nodes/types"
+)
+
+type StdTxMsg struct {
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+func ParseStdTxMsg(msg StdTxMsg) (transactionbuilder.TransactionMessage, error) {
+	switch msg.Type {
+	case "pos/Send":
+		parsedValue := msg.Value.(*nodesTypes.MsgSend)
+		return transactionbuilder.NewSend(parsedValue.FromAddress.String(), parsedValue.ToAddress.String(), parsedValue.Amount.Int64())
+	default:
+		return nil, nil
+	}
+}

--- a/utils/parse_stdtx_msg.go
+++ b/utils/parse_stdtx_msg.go
@@ -5,13 +5,13 @@ import (
 	nodesTypes "github.com/pokt-network/pocket-core/x/nodes/types"
 )
 
-// Represents 'StdTx' field from a Transaction
+// StdTxMsg represents 'StdTx' field from a Transaction
 type StdTxMsg struct {
 	Type  string      `json:"type"`
 	Value interface{} `json:"value"`
 }
 
-// This function parses any StdTx.Msg.Value and returns a typed struct
+// ParseStdTxMsg parses any StdTx.Msg.Value and returns a typed struct
 func ParseStdTxMsg(msg StdTxMsg) (transactionbuilder.TransactionMessage, error) {
 	switch msg.Type {
 	case "pos/Send":

--- a/utils/parse_stdtx_msg.go
+++ b/utils/parse_stdtx_msg.go
@@ -5,11 +5,13 @@ import (
 	nodesTypes "github.com/pokt-network/pocket-core/x/nodes/types"
 )
 
+// Represents 'StdTx' field from a Transaction
 type StdTxMsg struct {
 	Type  string      `json:"type"`
 	Value interface{} `json:"value"`
 }
 
+// This function parses any StdTx.Msg.Value and returns a typed struct
 func ParseStdTxMsg(msg StdTxMsg) (transactionbuilder.TransactionMessage, error) {
 	switch msg.Type {
 	case "pos/Send":


### PR DESCRIPTION
The `StdTx` field on the transaction struct varies on it's `Msg.Value` field. This utility function gives you the possibility to pass any message, and get a properly typed `Msg.Value` instead.

As it is a PoC, I only implemented it for the `Send` transaction.