### PR TITLE
refactor: add separated structs for api

### DIFF
--- a/provider/rpc_outputs.go
+++ b/provider/rpc_outputs.go
@@ -119,49 +119,6 @@ type GetBlockOutput struct {
 	} `json:"block_id"`
 }
 
-// GetTransactionOutput represents output for GetTransaction request
-type GetTransactionOutput struct {
-	Hash     string `json:"hash"`
-	Height   int    `json:"height"`
-	Index    int    `json:"index"`
-	TxResult struct {
-		Code        int      `json:"code"`
-		Data        string   `json:"data"`
-		Log         string   `json:"log"`
-		Info        string   `json:"info"`
-		Events      []string `json:"events"`
-		Codespace   string   `json:"codespace"`
-		Signer      string   `json:"signer"`
-		Recipient   string   `json:"recipient"`
-		MessageType string   `json:"message_type"`
-	} `json:"tx_result"`
-	Tx    string `json:"tx"`
-	Proof struct {
-		RootHash string `json:"root_hash"`
-		Data     string `json:"data"`
-		Proof    struct {
-			Total    int      `json:"total"`
-			Index    int      `json:"index"`
-			LeafHash string   `json:"leaf_hash"`
-			Aunts    []string `json:"aunts"`
-		} `json:"proof"`
-	} `json:"proof"`
-	StdTx struct {
-		Entropy int `json:"entropy"`
-		Fee     []struct {
-			Amount string `json:"amount"`
-			Denom  string `json:"denom"`
-		} `json:"fee"`
-		Memo string `json:"memo"`
-		Msg  struct {
-		} `json:"msg"`
-		Signature struct {
-			PubKey    string `json:"pub_key"`
-			Signature string `json:"signature"`
-		} `json:"signature"`
-	} `json:"stdTx"`
-}
-
 type queryHeightOutput struct {
 	Height int `json:"height"`
 }

--- a/provider/samples/query_tx.json
+++ b/provider/samples/query_tx.json
@@ -7,9 +7,7 @@
         "data": "string",
         "log": "string",
         "info": "string",
-        "events": [
-          "string"
-        ],
+        "events": "string",
         "codespace": "string",
         "signer": "string",
         "recipient": "string",

--- a/provider/transaction.go
+++ b/provider/transaction.go
@@ -25,6 +25,11 @@ type SendTransactionInput struct {
 	RawHexBytes string `json:"raw_hex_bytes"`
 }
 
+// GetTransactionOutput represents output for GetTransaction request
+type GetTransactionOutput struct {
+	*Transaction
+}
+
 // GetAccountTransactionsOutput represents output for GetAccountTransactions request
 type GetAccountTransactionsOutput struct {
 	PageCount int            `json:"page_count"`
@@ -53,20 +58,29 @@ type TransactionProof struct {
 
 // StdTx represents standard transaction fields
 type StdTx struct {
-	Entropy int64 `json:"entropy"`
-	Fee     []struct {
-		Amount string `json:"amount"`
-		Denom  string `json:"denom"`
-	} `json:"fee"`
-	Memo string `json:"memo"`
-	Msg  struct {
-		Type  string         `json:"type"`
-		Value map[string]any `json:"value"`
-	} `json:"msg"`
-	Signature struct {
-		PubKey    string `json:"pub_key"`
-		Signature string `json:"signature"`
-	} `json:"signature"`
+	Entropy   int64        `json:"entropy"`
+	Fee       []*Fee       `json:"fee"`
+	Memo      string       `json:"memo"`
+	Msg       *TxMsg       `json:"msg"`
+	Signature *TxSignature `json:"signature"`
+}
+
+// Fee represents fee values
+type Fee struct {
+	Amount string `json:"amount"`
+	Denom  string `json:"denom"`
+}
+
+// TxMsg represents message for transactions
+type TxMsg struct {
+	Type  string         `json:"type"`
+	Value map[string]any `json:"value"`
+}
+
+// TxSignature represents values of transaction signature
+type TxSignature struct {
+	PubKey    string `json:"pub_key"`
+	Signature string `json:"signature"`
 }
 
 // TxResult represents transaction result


### PR DESCRIPTION
Separate transaction structures for easier use in API service and simplified GetTransaction struct