### PR TITLE
feat: add func GetAllParams to provider

### DIFF
--- a/provider/options.go
+++ b/provider/options.go
@@ -42,6 +42,11 @@ type GetNodeOptions struct {
 	Height int
 }
 
+// GetAllParamsOptions represents optional arguments for GetAllParams request
+type GetAllParamsOptions struct {
+	Height int
+}
+
 // GetNodesOptions represents optional arguments for GetNodes request
 type GetNodesOptions struct {
 	Height        int

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -387,7 +387,12 @@ func (p *Provider) GetBlockHeight() (int, error) {
 }
 
 // GetAllParams returns the params at the specified height
-func (p *Provider) GetAllParams(height int) (*AllParams, error) {
+func (p *Provider) GetAllParams(options *GetAllParamsOptions) (*AllParams, error) {
+	var height int
+	if options != nil {
+		height = options.Height
+	}
+
 	params := map[string]interface{}{
 		"height": height,
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -386,6 +386,33 @@ func (p *Provider) GetBlockHeight() (int, error) {
 	return output.Height, nil
 }
 
+// GetAllParams returns the params at the specified height
+func (p *Provider) GetAllParams(height int) (*AllParams, error) {
+	params := map[string]interface{}{
+		"height": height,
+	}
+
+	rawOutput, err := p.doPostRequest("", params, QueryAllParamsRoute)
+
+	defer closeOrLog(rawOutput)
+
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := ioutil.ReadAll(rawOutput.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var allParams AllParams
+	if err = json.Unmarshal(respBody, &allParams); err != nil {
+		return nil, err
+	}
+
+	return &allParams, nil
+}
+
 // GetNodes returns a page of nodes known at the specified height and with options
 // empty options returns all validators, page < 1 returns the first page, per_page < 1 returns 10000 elements per page
 func (p *Provider) GetNodes(options *GetNodesOptions) (*GetNodesOutput, error) {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -220,7 +220,7 @@ func TestProvider_GetAllParams(t *testing.T) {
 
 	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", QueryAllParamsRoute), http.StatusOK, "samples/query_allparams.json")
 
-	allParams, err := provider.GetAllParams(0)
+	allParams, err := provider.GetAllParams(nil)
 	c.NoError(err)
 
 	relaysToTokensMultiplier, exists := allParams.NodeParams.Get("pos/RelaysToTokensMultiplier")

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -210,6 +210,24 @@ func TestProvider_GetBlockHeight(t *testing.T) {
 	c.Empty(blockNumber)
 }
 
+func TestProvider_GetAllParams(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	provider := NewProvider("https://dummy.com", []string{"https://dummy.com"})
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", QueryAllParamsRoute), http.StatusOK, "samples/query_allparams.json")
+
+	allParams, err := provider.GetAllParams(0)
+	c.NoError(err)
+
+	relaysToTokensMultiplier, exists := allParams.NodeParams.Get("pos/RelaysToTokensMultiplier")
+	c.True(exists)
+	c.Equal("2109", relaysToTokensMultiplier)
+}
+
 func TestProvider_GetNodes(t *testing.T) {
 	c := require.New(t)
 

--- a/provider/rpc_outputs.go
+++ b/provider/rpc_outputs.go
@@ -133,6 +133,34 @@ type GetAccountOutput struct {
 	PublicKey string `json:"public_key"`
 }
 
+// Param represents the output for a single param key value pair
+type Param struct {
+	Key   string `json:"param_key"`
+	Value string `json:"param_value"`
+}
+
+// ParamGroup is shorthand for a slice of Param
+type ParamGroup []Param
+
+// Get returns the value and existence state for a given key
+func (a ParamGroup) Get(k string) (string, bool) {
+	for _, p := range a {
+		if p.Key == k {
+			return p.Value, true
+		}
+	}
+	return "", false
+}
+
+// AllParams represents the output for AllParams request
+type AllParams struct {
+	AppParams    ParamGroup `json:"app_params"`
+	AuthParams   ParamGroup `json:"auth_params"`
+	GovParams    ParamGroup `json:"gov_params"`
+	NodeParams   ParamGroup `json:"node_params"`
+	PocketParams ParamGroup `json:"pocket_params"`
+}
+
 // DispatchOutput represents output for Dispatch request
 type DispatchOutput struct {
 	BlockHeight int      `json:"block_height"`

--- a/provider/samples/query_allparams.json
+++ b/provider/samples/query_allparams.json
@@ -1,0 +1,152 @@
+{
+  "app_params": [
+    {
+      "param_key": "application/MaximumChains",
+      "param_value": "15"
+    },
+    {
+      "param_key": "application/MaxApplications",
+      "param_value": "2295"
+    },
+    {
+      "param_key": "application/ApplicationStakeMinimum",
+      "param_value": "1000000"
+    },
+    {
+      "param_key": "application/AppUnstakingTime",
+      "param_value": "1814000000000000"
+    },
+    {
+      "param_key": "application/BaseRelaysPerPOKT",
+      "param_value": "200000"
+    },
+    {
+      "param_key": "application/ParticipationRateOn",
+      "param_value": "false"
+    },
+    {
+      "param_key": "application/StabilityAdjustment",
+      "param_value": "0"
+    }
+  ],
+  "auth_params": [
+    {
+      "param_key": "auth/MaxMemoCharacters",
+      "param_value": "75"
+    },
+    {
+      "param_key": "auth/TxSigLimit",
+      "param_value": "8"
+    },
+    {
+      "param_key": "auth/FeeMultipliers",
+      "param_value": "{\"fee_multiplier\":null,\"default\":\"1\"}"
+    }
+  ],
+  "gov_params": [
+    {
+      "param_key": "gov/daoOwner",
+      "param_value": "a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4"
+    },
+    {
+      "param_key": "gov/acl",
+      "param_value": "{\"type\":\"gov/non_map_acl\",\"value\":[{\"acl_key\":\"application/ApplicationStakeMinimum\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"application/AppUnstakingTime\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"application/BaseRelaysPerPOKT\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"application/MaxApplications\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"application/MaximumChains\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"application/ParticipationRateOn\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"application/StabilityAdjustment\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"auth/MaxMemoCharacters\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"auth/TxSigLimit\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"gov/acl\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"gov/daoOwner\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"gov/upgrade\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pocketcore/ClaimExpiration\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"auth/FeeMultipliers\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pocketcore/ReplayAttackBurnMultiplier\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/ProposerPercentage\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pocketcore/ClaimSubmissionWindow\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pocketcore/MinimumNumberOfProofs\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pocketcore/SessionNodeCount\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pocketcore/SupportedBlockchains\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/BlocksPerSession\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/DAOAllocation\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/DowntimeJailDuration\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/MaxEvidenceAge\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/MaximumChains\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/MaxJailedBlocks\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/MaxValidators\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/MinSignedPerWindow\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/RelaysToTokensMultiplier\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/SignedBlocksWindow\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/SlashFractionDoubleSign\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/SlashFractionDowntime\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/StakeDenom\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/StakeMinimum\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"},{\"acl_key\":\"pos/UnstakingTime\",\"address\":\"a83172b67b5ffbfcb8acb95acc0fd0466a9d4bc4\"}]}"
+    },
+    {
+      "param_key": "gov/upgrade",
+      "param_value": "{\"type\":\"gov/upgrade\",\"value\":{\"Height\":\"57616\",\"Version\":\"0.8.2\",\"OldUpgradeHeight\":\"45353\",\"Features\":[\"REDUP:57620\"]}}"
+    }
+  ],
+  "node_params": [
+    {
+      "param_key": "pos/RelaysToTokensMultiplier",
+      "param_value": "2109"
+    },
+    {
+      "param_key": "pos/StakeDenom",
+      "param_value": "upokt"
+    },
+    {
+      "param_key": "pos/StakeMinimum",
+      "param_value": "15000000000"
+    },
+    {
+      "param_key": "pos/ProposerPercentage",
+      "param_value": "1"
+    },
+    {
+      "param_key": "pos/SlashFractionDoubleSign",
+      "param_value": "0.000001000000000000"
+    },
+    {
+      "param_key": "pos/UnstakingTime",
+      "param_value": "1814000000000000"
+    },
+    {
+      "param_key": "pos/SignedBlocksWindow",
+      "param_value": "10"
+    },
+    {
+      "param_key": "pos/MaximumChains",
+      "param_value": "15"
+    },
+    {
+      "param_key": "pos/SlashFractionDowntime",
+      "param_value": "0.000001000000000000"
+    },
+    {
+      "param_key": "pos/BlocksPerSession",
+      "param_value": "4"
+    },
+    {
+      "param_key": "pos/DowntimeJailDuration",
+      "param_value": "3600000000000"
+    },
+    {
+      "param_key": "pos/MaxEvidenceAge",
+      "param_value": "120000000000"
+    },
+    {
+      "param_key": "pos/DAOAllocation",
+      "param_value": "10"
+    },
+    {
+      "param_key": "pos/MaxJailedBlocks",
+      "param_value": "37960"
+    },
+    {
+      "param_key": "pos/MaxValidators",
+      "param_value": "1000"
+    },
+    {
+      "param_key": "pos/MinSignedPerWindow",
+      "param_value": "0.600000000000000000"
+    }
+  ],
+  "pocket_params": [
+    {
+      "param_key": "pocketcore/SessionNodeCount",
+      "param_value": "24"
+    },
+    {
+      "param_key": "pocketcore/ClaimSubmissionWindow",
+      "param_value": "3"
+    },
+    {
+      "param_key": "pocketcore/SupportedBlockchains",
+      "param_value": "[\"0001\",\"0003\",\"0004\",\"0005\",\"0006\",\"0009\",\"000A\",\"000B\",\"000C\",\"0010\",\"0012\",\"0021\",\"0022\",\"0023\",\"0024\",\"0025\",\"0026\",\"0027\",\"0028\",\"0029\",\"0040\",\"0044\",\"0046\",\"0047\",\"0048\",\"0049\",\"0050\",\"0051\",\"0052\",\"0053\",\"03CB\",\"03DF\"]"
+    },
+    {
+      "param_key": "pocketcore/ClaimExpiration",
+      "param_value": "24"
+    },
+    {
+      "param_key": "pocketcore/MinimumNumberOfProofs",
+      "param_value": "10"
+    },
+    {
+      "param_key": "pocketcore/ReplayAttackBurnMultiplier",
+      "param_value": "3"
+    }
+  ]
+}


### PR DESCRIPTION
Adds to the Provider a method to query the the [/v1/query/allParams](https://github.com/pokt-network/pocket-core/blob/staging/doc/specs/rpc-spec.yaml#L347) endpoint, and corresponding types to handle the response.