### PR TITLE
feat: add calls with context to provider and use them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/pokt-foundation/utils-go v0.6.0
+	github.com/pokt-foundation/utils-go v0.7.0
 	github.com/pokt-network/pocket-core v0.0.0-20220412195259-d51116005a26
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-foundation/utils-go v0.6.0 h1:951VGbxSSgJs90lFoMhmb2esSDucQNX6I6Tp4NYBFuo=
-github.com/pokt-foundation/utils-go v0.6.0/go.mod h1:VMYNYtm1NKfCceLqzs6QSRhLcivafktirc3FSnB7Hxs=
+github.com/pokt-foundation/utils-go v0.7.0 h1:+BwAZj9Wfac6zkD4eQstRoz8lHc+6xBEtySys9WE5Ec=
+github.com/pokt-foundation/utils-go v0.7.0/go.mod h1:VMYNYtm1NKfCceLqzs6QSRhLcivafktirc3FSnB7Hxs=
 github.com/pokt-network/pocket-core v0.0.0-20220412195259-d51116005a26 h1:u31P5yZ8TCkQCfpLLpLCZ0t1EdcKoRWsqSpDoXZ9sfc=
 github.com/pokt-network/pocket-core v0.0.0-20220412195259-d51116005a26/go.mod h1:0w862E1EonKDe+jHYupBhMdtlBn7jlio9Eg+VQXFxoI=
 github.com/pokt-network/tendermint v0.32.11-0.20220330172101-d29c97194a7f h1:DJeK+takEPoDJOHGT9bDhSs3pVXAgq4fc8nK+KPGYes=

--- a/relayer/relayer_test.go
+++ b/relayer/relayer_test.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -93,6 +94,91 @@ func TestRelayer_Relay(t *testing.T) {
 	input.Node = &provider.Node{PublicKey: "AOG"}
 
 	relay, err = relayer.Relay(input, nil)
+	c.NoError(err)
+	c.NotEmpty(relay)
+}
+
+func TestRelayer_RelayWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	relayer := NewRelayer(nil, nil)
+	input := &Input{}
+
+	relay, err := relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(ErrNoSigner, err)
+	c.Empty(relay)
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	relayer.signer = signer
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(ErrNoProvider, err)
+	c.Empty(relay)
+
+	relayer.provider = provider.NewProvider("https://dummy.com", []string{"https://dummy.com"})
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(ErrNoSession, err)
+	c.Empty(relay)
+
+	input.Session = &provider.Session{}
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(ErrNoPocketAAT, err)
+	c.Empty(relay)
+
+	input.PocketAAT = &provider.PocketAAT{}
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(ErrSessionHasNoNodes, err)
+	c.Empty(relay)
+
+	input.Session.Nodes = []provider.Node{{PublicKey: "AOG"}}
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(ErrNoSessionHeader, err)
+	c.Empty(relay)
+
+	input.Session.Header = provider.SessionHeader{Chain: "chain"}
+	input.Node = &provider.Node{PublicKey: "PJOG"}
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(ErrNodeNotInSession, err)
+	c.Empty(relay)
+
+	input.Node = nil
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRelayRoute),
+		http.StatusInternalServerError, "../provider/samples/client_relay.json")
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.Equal(provider.Err5xxOnConnection, err)
+	c.Empty(relay)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRelayRoute),
+		http.StatusBadRequest, "../provider/samples/client_relay_error.json")
+
+	var relayError *provider.RelayError
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.ErrorAs(err, &relayError)
+	c.Empty(relay)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRelayRoute),
+		http.StatusOK, "../provider/samples/client_relay.json")
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
+	c.NoError(err)
+	c.NotEmpty(relay)
+
+	input.Node = &provider.Node{PublicKey: "AOG"}
+
+	relay, err = relayer.RelayWithCtx(context.Background(), input, nil)
 	c.NoError(err)
 	c.NotEmpty(relay)
 }

--- a/transaction-builder/transaction_builder.go
+++ b/transaction-builder/transaction_builder.go
@@ -3,6 +3,7 @@
 package transactionbuilder
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -54,7 +55,7 @@ var (
 
 // Provider interface representing provider functions necessary for Transaction Builder Package
 type Provider interface {
-	SendTransaction(input *provider.SendTransactionInput) (*provider.SendTransactionOutput, error)
+	SendTransactionWithCtx(ctx context.Context, input *provider.SendTransactionInput) (*provider.SendTransactionOutput, error)
 }
 
 // Signer interface representing signer functions necessary for Transaction Builder package
@@ -187,10 +188,15 @@ func (t *TransactionBuilder) CreateTransaction(chainID ChainID, txMsg Transactio
 
 // Submit does the transaction from raw input
 func (t *TransactionBuilder) Submit(chainID ChainID, txMsg TransactionMessage, options *TransactionOptions) (*provider.SendTransactionOutput, error) {
+	return t.SubmitWithCtx(context.Background(), chainID, txMsg, options)
+}
+
+// SubmitWithCtx does the transaction from raw input
+func (t *TransactionBuilder) SubmitWithCtx(ctx context.Context, chainID ChainID, txMsg TransactionMessage, options *TransactionOptions) (*provider.SendTransactionOutput, error) {
 	sendTransactionInput, err := t.CreateTransaction(chainID, txMsg, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return t.provider.SendTransaction(sendTransactionInput)
+	return t.provider.SendTransactionWithCtx(ctx, sendTransactionInput)
 }

--- a/transaction-builder/transaction_builder_test.go
+++ b/transaction-builder/transaction_builder_test.go
@@ -1,6 +1,7 @@
 package transactionbuilder
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -248,6 +249,246 @@ func TestTransactionBuilder_SubmitUnjailNode(t *testing.T) {
 		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
 
 	output, err = txBuilder.Submit(Mainnet, unjailNode, nil)
+	c.Empty(output)
+	c.Equal(provider.Err5xxOnConnection, err)
+}
+
+func TestTransactionBuilder_SubmitErrorWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	txBuilder := NewTransactionBuilder(nil, nil)
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), "", nil, nil)
+	c.Empty(output)
+	c.Equal(ErrNoProvider, err)
+
+	txBuilder.provider = provider.NewProvider("https://dummy.com", []string{"https://dummy.com"})
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), "", nil, nil)
+	c.Empty(output)
+	c.Equal(ErrNoSigner, err)
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder.signer = signer
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), "", nil, nil)
+	c.Empty(output)
+	c.Equal(ErrNoChainID, err)
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, nil, nil)
+	c.Empty(output)
+	c.Equal(ErrNoTransactionMessage, err)
+}
+
+func TestTransactionBuilder_SubmitMsgSendWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder := NewTransactionBuilder(provider.NewProvider("https://dummy.com", []string{"https://dummy.com"}), signer)
+
+	msgSend, err := NewSend("b50a6e20d3733fb89631ae32385b3c85c533c560", "b50a6e20d3733fb89631ae32385b3c85c533c561", 21)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusOK, "../provider/samples/client_raw_tx.json")
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), Mainnet, msgSend, &TransactionOptions{
+		CoinDenom: Upokt,
+		Fee:       23,
+		Memo:      "ohana",
+	})
+	c.NotEmpty(output)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, msgSend, nil)
+	c.Empty(output)
+	c.Equal(provider.Err5xxOnConnection, err)
+}
+
+func TestTransactionBuilder_SubmitStakeAppWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder := NewTransactionBuilder(provider.NewProvider("https://dummy.com", []string{"https://dummy.com"}), signer)
+
+	stakeApp, err := NewStakeApp("b243b27bc9fbe5580457a46370ae5f03a6f6753633e51efdaf2cf534fdc26cc3", []string{"0021"}, 21)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusOK, "../provider/samples/client_raw_tx.json")
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), Mainnet, stakeApp, nil)
+	c.NotEmpty(output)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, stakeApp, nil)
+	c.Empty(output)
+	c.Equal(provider.Err5xxOnConnection, err)
+}
+
+func TestTransactionBuilder_SubmitUnstakeAppWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder := NewTransactionBuilder(provider.NewProvider("https://dummy.com", []string{"https://dummy.com"}), signer)
+
+	unstakeApp, err := NewUnstakeApp("b50a6e20d3733fb89631ae32385b3c85c533c560")
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusOK, "../provider/samples/client_raw_tx.json")
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), Mainnet, unstakeApp, nil)
+	c.NoError(err)
+	c.NotEmpty(output)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, unstakeApp, nil)
+	c.Empty(output)
+	c.Equal(provider.Err5xxOnConnection, err)
+}
+
+func TestTransactionBuilder_SubmitUnjailAppWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder := NewTransactionBuilder(provider.NewProvider("https://dummy.com", []string{"https://dummy.com"}), signer)
+
+	unjailApp, err := NewUnjailApp("b50a6e20d3733fb89631ae32385b3c85c533c560")
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusOK, "../provider/samples/client_raw_tx.json")
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), Mainnet, unjailApp, nil)
+	c.NotEmpty(output)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, unjailApp, nil)
+	c.Empty(output)
+	c.Equal(provider.Err5xxOnConnection, err)
+}
+
+func TestTransactionBuilder_SubmitStakeNodeWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder := NewTransactionBuilder(provider.NewProvider("https://dummy.com", []string{"https://dummy.com"}), signer)
+
+	stakeNode, err := NewStakeNode("b243b27bc9fbe5580457a46370ae5f03a6f6753633e51efdaf2cf534fdc26cc3", "https://dummy.com:443",
+		"b50a6e20d3733fb89631ae32385b3c85c533c560", []string{"0021"}, 21)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusOK, "../provider/samples/client_raw_tx.json")
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), Mainnet, stakeNode, nil)
+	c.NotEmpty(output)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, stakeNode, nil)
+	c.Empty(output)
+	c.Equal(provider.Err5xxOnConnection, err)
+}
+
+func TestTransactionBuilder_SubmitUnstakeNodeWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder := NewTransactionBuilder(provider.NewProvider("https://dummy.com", []string{"https://dummy.com"}), signer)
+
+	unstakeNode, err := NewUnstakeNode("b50a6e20d3733fb89631ae32385b3c85c533c560", "b50a6e20d3733fb89631ae32385b3c85c533c561")
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusOK, "../provider/samples/client_raw_tx.json")
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), Mainnet, unstakeNode, nil)
+	c.NotEmpty(output)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, unstakeNode, nil)
+	c.Empty(output)
+	c.Equal(provider.Err5xxOnConnection, err)
+}
+
+func TestTransactionBuilder_SubmitUnjailNodeWithCtx(t *testing.T) {
+	c := require.New(t)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	signer, err := signer.NewRandomSigner()
+	c.NoError(err)
+
+	txBuilder := NewTransactionBuilder(provider.NewProvider("https://dummy.com", []string{"https://dummy.com"}), signer)
+
+	unjailNode, err := NewUnjailNode("b50a6e20d3733fb89631ae32385b3c85c533c560", "b50a6e20d3733fb89631ae32385b3c85c533c561")
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusOK, "../provider/samples/client_raw_tx.json")
+
+	output, err := txBuilder.SubmitWithCtx(context.Background(), Mainnet, unjailNode, nil)
+	c.NotEmpty(output)
+	c.NoError(err)
+
+	mock.AddMockedResponseFromFile(http.MethodPost, fmt.Sprintf("%s%s", "https://dummy.com", provider.ClientRawTXRoute),
+		http.StatusInternalServerError, "../provider/samples/client_raw_tx.json")
+
+	output, err = txBuilder.SubmitWithCtx(context.Background(), Mainnet, unjailNode, nil)
 	c.Empty(output)
 	c.Equal(provider.Err5xxOnConnection, err)
 }


### PR DESCRIPTION
Add functions with context as param to the provider package and use those in the relayer and the transaction builder